### PR TITLE
Endpoint configuration name length exceeds allowed length (63 characters)

### DIFF
--- a/module-3/sagemaker-projects-portfolio/service_catalog/sm_projects_products/deploy_projects/deploy_model_product/seed_code/deploy_endpoint/deploy_endpoint_stack.py
+++ b/module-3/sagemaker-projects-portfolio/service_catalog/sm_projects_products/deploy_projects/deploy_model_product/seed_code/deploy_endpoint/deploy_endpoint_stack.py
@@ -190,6 +190,8 @@ class DeployEndpointStack(Stack):
 
         # Sagemaker Endpoint Config
         endpoint_config_name = f"{MODEL_PACKAGE_GROUP_NAME}-ec-{timestamp}"
+        if len(endpoint_config_name) > 63:
+            endpoint_config_name = endpoint_config_name[:62]
 
         endpoint_config_production_variant = EndpointConfigProductionVariant()
 
@@ -233,7 +235,7 @@ class DeployEndpointStack(Stack):
         endpoint = sagemaker.CfnEndpoint(
             self,
             "Endpoint",
-            endpoint_config_name=endpoint_config.endpoint_config_name, # type: ignore
+            endpoint_config_name=endpoint_config.endpoint_config_name,  # type: ignore
             endpoint_name=endpoint_name,
         )
 


### PR DESCRIPTION
Fixes #12

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
